### PR TITLE
Scala sealed trait ability (mostly) in dataconf using dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,26 +73,34 @@ print(dataconf.load(conf, Config))
 # Replicating pureconfig Scala sealed trait case class behavior
 # https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html
 class InputType:
-    @dataclass(init=True, repr=True)
-    class StringImpl:
-        name: Text
-        age: Text
+    """
+    Abstract base class
+    """
+    pass
+    
+    
+@dataclass(init=True, repr=True)
+class StringImpl(InputType):
+    name: Text
+    age: Text
 
-        def test_method(self):
-            print(f"{self.name} is {self.age} years old.")
+    def test_method(self):
+        print(f"{self.name} is {self.age} years old.")
 
-    @dataclass(init=True, repr=True)
-    class IntImpl:
-        area_code: int
-        phone_num: Text
+        
+@dataclass(init=True, repr=True)
+class IntImpl(InputType):
+    area_code: int
+    phone_num: Text
 
-        def test_method(self):
-            print(f"The area code for {self.phone_num} is {str(self.area_code)}")
+    def test_method(self):
+        print(f"The area code for {self.phone_num} is {str(self.area_code)}")
 
+        
 @dataclass
 class Base:
     location: Text
-    input_source: Union[InputType.StringImpl, InputType.IntImpl]
+    input_source: InputType
 
 str_conf = """
 {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,42 @@ class Config:
 
 print(dataconf.load(conf, Config))
 # TestConf(test='pc.home', float=2.1, default='hello', list=['a', 'b'], nested=Nested(a='test'), nested_list=[Nested(a='test1')], duration=relativedelta(seconds=+2), default_factory={}, union=1)
+
+# Replicating pureconfig Scala sealed trait case class behavior
+# https://pureconfig.github.io/docs/overriding-behavior-for-sealed-families.html
+class InputType:
+    @dataclass(init=True, repr=True)
+    class StringImpl:
+        name: Text
+        age: Text
+
+        def test_method(self):
+            print(f"{self.name} is {self.age} years old.")
+
+    @dataclass(init=True, repr=True)
+    class IntImpl:
+        area_code: int
+        phone_num: Text
+
+        def test_method(self):
+            print(f"The area code for {self.phone_num} is {str(self.area_code)}")
+
+@dataclass
+class Base:
+    location: Text
+    input_source: InputType
+
+str_conf = """
+{
+    location: Europe
+    input_source {
+        name: Thailand
+        age: "12"
+    }
+}
+"""
+
+conf = dataconf.loads(str_conf, Base)
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class InputType:
 @dataclass
 class Base:
     location: Text
-    input_source: InputType
+    input_source: Union[InputType.StringImpl, InputType.IntImpl]
 
 str_conf = """
 {

--- a/dataconf/__init__.py
+++ b/dataconf/__init__.py
@@ -2,5 +2,6 @@ from dataconf.utils import dump
 from dataconf.utils import dumps
 from dataconf.utils import load
 from dataconf.utils import loads
+from dataconf.version import __version__
 
 __all__ = ["load", "loads", "dump", "dumps"]

--- a/dataconf/__init__.py
+++ b/dataconf/__init__.py
@@ -4,4 +4,4 @@ from dataconf.utils import load
 from dataconf.utils import loads
 from dataconf.version import __version__
 
-__all__ = ["load", "loads", "dump", "dumps"]
+__all__ = ["load", "loads", "dump", "dumps", "__version__"]

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -118,11 +118,12 @@ def __parse(value: any, clazz, path):
     #       if subclasses are a dataclass parse values
     #       the idea here is to replicate parsing of a sealed trait in Scala
     #       when using pureconfig
-    for sub_data in [i for i in dir(clazz) if is_dataclass(getattr(clazz, i))]:
-        if set([i.name for i in fields(getattr(clazz, sub_data))]) == set(value.keys()):
-            # currently failing since the new data class is subclass type
-            # but the type passed
-            return __parse(value, getattr(clazz, sub_data), "")
+    for key in dir(clazz):
+        nested_class = getattr(clazz, key)
+        if is_dataclass(nested_class):
+            field_keys = set([i.name for i in fields(getattr(clazz, nested_class))])
+            if field_keys == set(value.keys()):
+                return __parse(value, getattr(clazz, nested_class), "")
 
     raise TypeConfigException(f"expected type {clazz} at {path}, got {type(value)}")
 

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -121,9 +121,11 @@ def __parse(value: any, clazz, path):
     for key in dir(clazz):
         nested_class = getattr(clazz, key)
         if is_dataclass(nested_class):
-            field_keys = set([i.name for i in fields(getattr(clazz, nested_class))])
+            field_keys = set(
+                [i.name for i in fields(getattr(clazz, nested_class.__name__))]
+            )
             if field_keys == set(value.keys()):
-                return __parse(value, getattr(clazz, nested_class), "")
+                return __parse(value, getattr(clazz, nested_class.__name__), "")
 
     raise TypeConfigException(f"expected type {clazz} at {path}, got {type(value)}")
 

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -118,7 +118,6 @@ def __parse(value: any, clazz, path):
     #       if subclasses are a dataclass parse values
     #       the idea here is to replicate parsing of a sealed trait in Scala
     #       when using pureconfig
-    print(value)
     for sub_data in [i for i in dir(clazz) if is_dataclass(getattr(clazz, i))]:
         if set([i.name for i in fields(getattr(clazz, sub_data))]) == set(value.keys()):
             # currently failing since the new data class is subclass type

--- a/dataconf/version.py
+++ b/dataconf/version.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("dataconf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dataconf"
-version = "0.1.5"
+version = "0.1.6"
 description = "Lightweight configuration with automatic dataclasses parsing (HOCON/JSON/YAML/PROPERTIES)"
 authors = []
 license = "Apache2"

--- a/tests/scala_sealed_trait.py
+++ b/tests/scala_sealed_trait.py
@@ -3,24 +3,28 @@ from typing import Text
 
 
 class InputType:
-    @dataclass(init=True, repr=True)
-    class StringImpl:
-        name: Text
-        age: Text
+    pass
 
-        def test_method(self):
-            return f"{self.name} is {self.age} years old."
 
-        def test_complex(self):
-            return int(self.age) * 3
+@dataclass(init=True, repr=True)
+class StringImpl(InputType):
+    name: Text
+    age: Text
 
-    @dataclass(init=True, repr=True)
-    class IntImpl:
-        area_code: int
-        phone_num: Text
+    def test_method(self):
+        return f"{self.name} is {self.age} years old."
 
-        def test_method(self):
-            return f"The area code for {self.phone_num} is {str(self.area_code)}"
+    def test_complex(self):
+        return int(self.age) * 3
 
-        def test_complex(self):
-            return self.area_code - 10
+
+@dataclass(init=True, repr=True)
+class IntImpl(InputType):
+    area_code: int
+    phone_num: Text
+
+    def test_method(self):
+        return f"The area code for {self.phone_num} is {str(self.area_code)}"
+
+    def test_complex(self):
+        return self.area_code - 10

--- a/tests/scala_sealed_trait.py
+++ b/tests/scala_sealed_trait.py
@@ -11,6 +11,9 @@ class InputType:
         def test_method(self):
             return f"{self.name} is {self.age} years old."
 
+        def test_complex(self):
+            return int(self.age) * 3
+
     @dataclass(init=True, repr=True)
     class IntImpl:
         area_code: int
@@ -18,3 +21,6 @@ class InputType:
 
         def test_method(self):
             return f"The area code for {self.phone_num} is {str(self.area_code)}"
+
+        def test_complex(self):
+            return self.area_code - 10

--- a/tests/scala_sealed_trait.py
+++ b/tests/scala_sealed_trait.py
@@ -9,7 +9,7 @@ class InputType:
         age: Text
 
         def test_method(self):
-            print(f"{self.name} is {self.age} years old.")
+            return f"{self.name} is {self.age} years old."
 
     @dataclass(init=True, repr=True)
     class IntImpl:
@@ -17,4 +17,4 @@ class InputType:
         phone_num: Text
 
         def test_method(self):
-            print(f"The area code for {self.phone_num} is {str(self.area_code)}")
+            return f"The area code for {self.phone_num} is {str(self.area_code)}"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -268,6 +268,7 @@ class TestParser:
             input_source=InputType.StringImpl(name="Thailand", age="12")
         )
         assert conf.input_source.test_method() == "Thailand is 12 years old."
+        assert conf.input_source.test_complex() == 36
 
     def test_traits_int_impl(self) -> None:
         @dataclass
@@ -291,3 +292,4 @@ class TestParser:
             input_source=InputType.IntImpl(area_code=94, phone_num="1234567")
         )
         assert conf.input_source.test_method() == "The area code for 1234567 is 94"
+        assert conf.input_source.test_complex() == 84

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,8 +13,7 @@ from dataconf.exceptions import MissingTypeException
 from dataconf.exceptions import UnexpectedKeysException
 from dateutil.relativedelta import relativedelta
 import pytest
-
-from .scala_sealed_trait import InputType
+from tests.scala_sealed_trait import InputType
 
 
 PARENT_DIR = os.path.normpath(
@@ -248,7 +247,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType()
+            input_source: Union[InputType.StringImpl, InputType.IntImpl]
 
         str_conf = """
         {
@@ -272,7 +271,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType()
+            input_source: Union[InputType.StringImpl, InputType.IntImpl]
 
         str_conf = """
         {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -244,8 +244,6 @@ class TestParser:
             conn=Conn(host="test.server.io", port=443),
         )
 
-    # Todo: input_source: InputType.__class__ should be passed
-    #       causes abstract method error will looking into it later
     def test_traits_string_impl(self) -> None:
         @dataclass
         class Base:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -249,7 +249,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType()
+            input_source: InputType
 
         str_conf = """
         {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -250,7 +250,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType
+            input_source: InputType()
 
         str_conf = """
         {
@@ -267,12 +267,13 @@ class TestParser:
             location="Europe",
             input_source=InputType.StringImpl(name="Thailand", age="12")
         )
+        assert conf.input_source.test_method() == "Thailand is 12 years old."
 
     def test_traits_int_impl(self) -> None:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType
+            input_source: InputType()
 
         str_conf = """
         {
@@ -289,3 +290,4 @@ class TestParser:
             location="Europe",
             input_source=InputType.IntImpl(area_code=94, phone_num="1234567")
         )
+        assert conf.input_source.test_method() == "The area code for 1234567 is 94"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,6 +14,8 @@ from dataconf.exceptions import UnexpectedKeysException
 from dateutil.relativedelta import relativedelta
 import pytest
 from tests.scala_sealed_trait import InputType
+from tests.scala_sealed_trait import IntImpl
+from tests.scala_sealed_trait import StringImpl
 
 
 PARENT_DIR = os.path.normpath(
@@ -247,7 +249,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: Union[InputType.StringImpl, InputType.IntImpl]
+            input_source: InputType()
 
         str_conf = """
         {
@@ -262,7 +264,7 @@ class TestParser:
         conf = loads(str_conf, Base)
         assert conf == Base(
             location="Europe",
-            input_source=InputType.StringImpl(name="Thailand", age="12"),
+            input_source=StringImpl(name="Thailand", age="12"),
         )
         assert conf.input_source.test_method() == "Thailand is 12 years old."
         assert conf.input_source.test_complex() == 36
@@ -271,7 +273,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: InputType()
+            input_source: InputType
 
         str_conf = """
         {
@@ -286,7 +288,7 @@ class TestParser:
         conf = loads(str_conf, Base)
         assert conf == Base(
             location="Europe",
-            input_source=InputType.IntImpl(area_code=94, phone_num="1234567"),
+            input_source=IntImpl(area_code=94, phone_num="1234567"),
         )
         assert conf.input_source.test_method() == "The area code for 1234567 is 94"
         assert conf.input_source.test_complex() == 84

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -263,7 +263,7 @@ class TestParser:
         conf = loads(str_conf, Base)
         assert conf == Base(
             location="Europe",
-            input_source=InputType.StringImpl(name="Thailand", age="12")
+            input_source=InputType.StringImpl(name="Thailand", age="12"),
         )
         assert conf.input_source.test_method() == "Thailand is 12 years old."
         assert conf.input_source.test_complex() == 36
@@ -287,7 +287,7 @@ class TestParser:
         conf = loads(str_conf, Base)
         assert conf == Base(
             location="Europe",
-            input_source=InputType.IntImpl(area_code=94, phone_num="1234567")
+            input_source=InputType.IntImpl(area_code=94, phone_num="1234567"),
         )
         assert conf.input_source.test_method() == "The area code for 1234567 is 94"
         assert conf.input_source.test_complex() == 84

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -271,7 +271,7 @@ class TestParser:
         @dataclass
         class Base:
             location: Text
-            input_source: Union[InputType.StringImpl, InputType.IntImpl]
+            input_source: InputType()
 
         str_conf = """
         {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from typing import Union
 
 from dataconf import load
 from dataconf import loads
+import dataconf.exceptions
 from dataconf.exceptions import MissingTypeException
 from dataconf.exceptions import UnexpectedKeysException
 from dateutil.relativedelta import relativedelta
@@ -292,3 +293,29 @@ class TestParser:
         )
         assert conf.input_source.test_method() == "The area code for 1234567 is 94"
         assert conf.input_source.test_complex() == 84
+
+    def test_traits_failure(self) -> None:
+        @dataclass
+        class Base:
+            location: Text
+            input_source: InputType
+
+        str_conf = """
+                {
+                    location: Europe
+                    input_source {
+                        name: Thailand
+                        age: "12"
+                        city: Paris
+                    }
+                }
+                """
+
+        with pytest.raises(Exception) as e:
+            loads(str_conf, Base)
+
+        assert e.type == dataconf.exceptions.UnexpectedKeysException
+        assert (
+            e.value.args[0] == "unexpected keys city detected for type <class "
+            "'tests.scala_sealed_trait.StringImpl'> at .input_source"
+        )


### PR DESCRIPTION
@zifeo added the ability for nested dataclass methods (sealed trait pureconfig functionality in Scala), updated README, incremented to 0.1.6, and created version.py which will provide __version__ and get the latest from the pyproject.toml

Also, on my local, the following test always fails. How do I get it to pass?
```python
tests/test_parser.py:186 (TestParser.test_missing_type)
self = <tests.test_parser.TestParser object at 0x7fe398c417c0>

    def test_missing_type(self) -> None:
    
        with pytest.raises(MissingTypeException):
>           loads("", Dict)
E           Failed: DID NOT RAISE <class 'dataconf.exceptions.MissingTypeException'>
```