### PR TITLE
add parse to __init__ so we can access parse (useful on config tree)

### DIFF
--- a/dataconf/__init__.py
+++ b/dataconf/__init__.py
@@ -5,6 +5,7 @@ from dataconf.main import file
 from dataconf.main import load
 from dataconf.main import loads
 from dataconf.main import multi
+from dataconf.main import parse
 from dataconf.main import string
 from dataconf.main import url
 from dataconf.version import __version__
@@ -19,5 +20,6 @@ __all__ = [
     "file",
     "string",
     "multi",
+    "parse",
     "__version__",
 ]


### PR DESCRIPTION
added parse to __init__ so it is available on import without needing to import main; useful if someone has to pass part of a config, a config tree, on to another library.