### PR TITLE
fix: Add Support for string Enum

### DIFF
--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -181,6 +181,8 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
     if isclass(clazz) and (issubclass(clazz, Enum) or issubclass(clazz, IntEnum)):
         if isinstance(value, int):
             return clazz.__call__(value)
+        elif issubclass(clazz, str):
+            return clazz(value)
         elif isinstance(value, str):
             return clazz.__getattr__(value)
         else:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -180,6 +180,21 @@ class TestParser:
         """
         assert loads(conf, A) == A(b="test")
 
+    def test_str_enum(self) -> None:
+        class Color(str, Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        @dataclass
+        class A:
+            b: Color
+
+        conf_value = """
+        b = red
+        """
+        assert loads(conf_value, A) == A(b=Color.RED)
+
     def test_enum(self) -> None:
         class Color(Enum):
             RED = 1


### PR DESCRIPTION
Hey I have an issue when working with String Enums, it fails with an **Attribute Error**. 

Simple simulation of the error : 

```
from enum import Enum
import dataconf
import json
from dataclasses import dataclass


class Granularity(str, Enum):
    HOURLY = "hourly"
    DAILY = "daily"


@dataclass
class Configuration:
    granularity: Granularity


def load_from_dict(configuration: dict):
    json_conf = json.dumps(configuration)
    return dataconf.loads(json_conf, Configuration, ignore_unexpected=True)


configuration = {"granularity": "hourly"}
load_from_dict(configuration)
```

With the proposed change, it works fine
