### PR TITLE
fix: for issue with nested dataclasses that have default values

### DIFF
--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -68,6 +68,9 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
                     val = f.default_factory()
                 else:
                     val = f.default
+                if is_dataclass(val):
+                    # if val is a dataclass, convert to ConfigTree
+                    val = ConfigTree(asdict(val))
 
             if not isinstance(val, _MISSING_TYPE):
                 fs[f.name] = __parse(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -690,3 +690,27 @@ class TestParser:
         assert url(httpserver.url_for("/simple.json"), A) == A(
             hello="bonjour", foo=["bar"]
         )
+
+    def test_nested_with_defaults(self):
+        @dataclass
+        class Nested:
+            nested_a: bool = False
+            nested_b: str = field(default="some default value")
+
+        @dataclass
+        class TopLevel:
+            top_a: str
+            top_b: str = field(default="some other value")
+            top_c: Nested = field(
+                default_factory=Nested
+            )  # nested dataclass with a default factory
+
+        config_string = """
+        top_a: "some value"
+        """
+
+        assert loads(config_string, TopLevel, loader=dataconf.YAML) == TopLevel(
+            top_a="some value",
+            top_b="some other value",
+            top_c=Nested(nested_a=False, nested_b="some default value"),
+        )


### PR DESCRIPTION
When using nested dataclasses that have defaults, the current behavior is to call the `default_factory` or get the `default` value of the dataclass. This works fine if the default is a literal, but when the default is a nested dataclass this raises the issue described in #97

This PR attempts to fix the issue by testing if the resulting default value is a dataclass, and if so converting it to a `ConfigTree` instance