### PR TITLE
feat: Adding literal support

### DIFF
--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -7,7 +7,7 @@ from enum import Enum
 from enum import IntEnum
 from inspect import isclass
 
-from typing import Any
+from typing import Any, Literal
 from typing import Dict
 from typing import get_args
 from typing import get_origin
@@ -199,6 +199,13 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
             return clazz.__getattr__(value)
 
         raise TypeConfigException(f"expected str or int at {path}, got {type(value)}")
+
+    if get_origin(clazz) is (Literal):
+        if value in args:
+            return value
+        raise TypeConfigException(
+            f"expected one of {', '.join(map(str, args))} at {path}, got {value}"
+        )
 
     if clazz is datetime:
         dt = __parse_type(value, clazz, path, isinstance(value, str))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -5,7 +5,7 @@ from datetime import timezone
 from enum import Enum
 from enum import IntEnum
 import os
-from typing import Any
+from typing import Any, Literal
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -712,3 +712,38 @@ class TestParser:
             top_b="some other value",
             top_c=Nested(nested_a=False, nested_b="some default value"),
         )
+
+    def test_literals(self):
+        @dataclass
+        class Something:
+            literal: Literal["a", "b", 3] = field(default="a")
+
+        config_string = """
+        literal: "a"
+        """
+
+        assert loads(config_string, Something, loader=dataconf.YAML) == Something(
+            literal="a"
+        )
+
+        config_string = """
+        literal: "b"
+        """
+
+        assert loads(config_string, Something, loader=dataconf.YAML) == Something(
+            literal="b"
+        )
+
+        config_string = """
+        literal: 3
+        """
+
+        assert loads(config_string, Something, loader=dataconf.YAML) == Something(
+            literal=3
+        )
+
+        with pytest.raises(TypeConfigException):
+            config_string = """
+            literal: "d"
+            """
+            loads(config_string, Something, loader=dataconf.YAML)


### PR DESCRIPTION
Adding support for `typing.Literal` fields, which behave similar to `Enums`, allowing for stuff such as:
```python
class Something:
    literal: Literal["a", "b", 3] = field(default="a")
```