### PR TITLE
feat: add support for `pathlib.Path` type

### DIFF
--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from enum import Enum
 from enum import IntEnum
 from inspect import isclass
+from pathlib import Path
 
 from typing import Any, Literal
 from typing import Dict
@@ -199,6 +200,9 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
             return clazz.__getattr__(value)
 
         raise TypeConfigException(f"expected str or int at {path}, got {type(value)}")
+
+    if isclass(clazz) and issubclass(clazz, Path):
+        return clazz.__call__(value)
 
     if get_origin(clazz) is (Literal):
         if value in args:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -5,6 +5,7 @@ from datetime import timezone
 from enum import Enum
 from enum import IntEnum
 import os
+from pathlib import Path
 from typing import Any, Literal
 from typing import Dict
 from typing import List
@@ -268,6 +269,16 @@ class TestParser:
         b = 2
         """
         assert loads(conf_value, A) == A(b=IntColor.GREEN)
+
+    def test_path(self) -> None:
+        @dataclass
+        class P:
+            p: Path
+
+        conf_name = """
+        p = /tmp/test.yaml
+        """
+        assert loads(conf_name, P) == P(p=Path("/tmp/test.yaml"))
 
     def test_datetime(self) -> None:
         @dataclass


### PR DESCRIPTION
I am looking for a replacement for `ConfZ` which uses native `dataclasses` instead of `Pydantic`. Ported my first (simple) configuration to `dataconf` and was missing `Path` (de)serialization/type support.