### PR TITLE
feat: add timedelta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ str_name = ${?HOME}
 dash-to-underscore = true
 float_num = 2.2
 iso_datetime = "2000-01-01T20:00:00"
+iso_duration = "P123DT4H5M6S"
 # this is a comment
 list_data = [
     a
@@ -87,6 +88,7 @@ class Config:
     dash_to_underscore: bool
     float_num: float
     iso_datetime: datetime
+    iso_duration: timedelta
     list_data: List[Text]
     nested: Nested
     nested_list: List[Nested]

--- a/confs/readme.hocon
+++ b/confs/readme.hocon
@@ -3,6 +3,7 @@ str_name = ${?HOME}
 dash-to-underscore = true
 float_num = 2.2
 iso_datetime = "2000-01-01T20:00:00"
+iso_duration = "P123DT4H5M6S"
 # this is a comment
 list_data = [
     a

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -228,7 +228,9 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
         try:
             duration = parse_duration(dt)
             if isinstance(duration, Duration):
-                raise ParseException("The ISO 8601 duration provided can not contain years or months")
+                raise ParseException(
+                    "The ISO 8601 duration provided can not contain years or months"
+                )
             return duration
         except ValueError as e:
             raise ParseException(

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from dataclasses import fields
 from dataclasses import is_dataclass
 from datetime import datetime
+from datetime import timedelta
 from enum import Enum
 from enum import IntEnum
 from inspect import isclass
@@ -28,6 +29,8 @@ from dateutil.relativedelta import relativedelta
 from pyhocon import ConfigFactory
 from pyhocon.config_tree import ConfigList
 from pyhocon.config_tree import ConfigTree
+from isodate import parse_duration
+from isodate import Duration
 import pyparsing
 
 from dataconf.version import PY310up
@@ -215,6 +218,18 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
         dt = __parse_type(value, clazz, path, isinstance(value, str))
         try:
             return isoparse(dt)
+        except ValueError as e:
+            raise ParseException(
+                f"expected type {clazz} at {path}, cannot parse due to {e}"
+            )
+
+    if clazz is timedelta:
+        dt = __parse_type(value, clazz, path, isinstance(value, str))
+        try:
+            duration = parse_duration(dt)
+            if isinstance(duration, Duration):
+                raise ParseException("The ISO 8601 duration provided can not contain years or months")
+            return duration
         except ValueError as e:
             raise ParseException(
                 f"expected type {clazz} at {path}, cannot parse due to {e}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -256,6 +256,20 @@ files = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.6.1"
+description = "An ISO 8601 date/time/duration parser and formatter"
+optional = false
+python-versions = "*"
+files = [
+    {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
+    {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "jinja2"
 version = "3.1.3"
 description = "A very fast and expressive template engine."
@@ -530,6 +544,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -733,4 +748,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a3cbd0b18a3a1e80e092970a17ab376f35f381a5912a6814d156580aed802d26"
+content-hash = "a1fa9cb2bac28062b7abd7c59774943d5599f360dc750b7af054e3b55558586a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -748,4 +748,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a1fa9cb2bac28062b7abd7c59774943d5599f360dc750b7af054e3b55558586a"
+content-hash = "814534c582bdcea54df75d8264b6fca3787327d20e7ca6ab95af5f03ea0c8791"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pyhocon = "0.3.59"
 python-dateutil = "^2.8.2"
 PyYAML = "^6.0.1"
 pyparsing = "2.4.7"
+isodate = "^0.6.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from enum import Enum
 from enum import IntEnum
@@ -299,6 +300,51 @@ class TestParser:
 
         conf = """
         b = "1997-07-16 19:20:0701:00"
+        """
+        with pytest.raises(ParseException):
+            assert loads(conf, A)
+
+    def test_duration(self) -> None:
+        @dataclass
+        class A:
+            b: timedelta
+
+        conf = """
+        b = "P123DT4H5M6S"
+        """
+        assert loads(conf, A) == A(
+            b=timedelta(days=123, hours=4, minutes=5, seconds=6)
+        )
+
+    def test_bad_duration(self) -> None:
+        @dataclass
+        class A:
+            b: timedelta
+
+        conf = """
+        b = "P123D4H5M6S"
+        """
+        with pytest.raises(ParseException):
+            assert loads(conf, A)
+
+    def test_unsupported_duration_with_year(self) -> None:
+        @dataclass
+        class A:
+            b: timedelta
+
+        conf = """
+        b = "P1Y"
+        """
+        with pytest.raises(ParseException):
+            assert loads(conf, A)
+
+    def test_unsupported_duration_with_month(self) -> None:
+        @dataclass
+        class A:
+            b: timedelta
+
+        conf = """
+        b = "P1M"
         """
         with pytest.raises(ParseException):
             assert loads(conf, A)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -312,9 +312,7 @@ class TestParser:
         conf = """
         b = "P123DT4H5M6S"
         """
-        assert loads(conf, A) == A(
-            b=timedelta(days=123, hours=4, minutes=5, seconds=6)
-        )
+        assert loads(conf, A) == A(b=timedelta(days=123, hours=4, minutes=5, seconds=6))
 
     def test_bad_duration(self) -> None:
         @dataclass

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2,6 +2,7 @@ from abc import ABCMeta
 from dataclasses import dataclass
 from dataclasses import field
 from datetime import datetime
+from datetime import timedelta
 import os
 import tempfile
 from typing import Dict
@@ -45,6 +46,7 @@ class TestParser:
             dash_to_underscore: bool
             float_num: float
             iso_datetime: datetime
+            iso_duration: timedelta
             list_data: List[Text]
             nested: Nested
             nested_list: List[Nested]
@@ -63,6 +65,7 @@ class TestParser:
             dash_to_underscore=True,
             float_num=2.2,
             iso_datetime=datetime(2000, 1, 1, 20),
+            iso_duration=timedelta(days=123, hours=4, minutes=5, seconds=6),
             list_data=["a", "b"],
             nested=Nested(a="test", b=1),
             nested_list=[Nested(a="test1", b=2.5)],


### PR DESCRIPTION
As requested in #133, I have added support for parsing and converting an ISO 8601 duration to a `timedelta`. Additionally, I have added automated tests to verify the behavior and a usage example in the `README.md`. Please feel free to let me know if I failed to add tests somewhere that should really include some tests.