### PR TITLE
feat: add support for tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ pre-commit install
 ```python
 import os
 from dataclasses import dataclass, field
-from typing import List, Dict, Text, Union
+from typing import List, Dict, Text, Union, Tuple
 from dateutil.relativedelta import relativedelta
-from datetime import datetime
+from datetime import datetime, timedelta
 import dataconf
 
 conf = """
@@ -41,6 +41,10 @@ dash-to-underscore = true
 float_num = 2.2
 iso_datetime = "2000-01-01T20:00:00"
 iso_duration = "P123DT4H5M6S"
+tuple_data = [
+    a
+    P1D
+]
 # this is a comment
 list_data = [
     a
@@ -89,6 +93,7 @@ class Config:
     float_num: float
     iso_datetime: datetime
     iso_duration: timedelta
+    tuple_data: Tuple[Text, timedelta]
     list_data: List[Text]
     nested: Nested
     nested_list: List[Nested]
@@ -101,17 +106,20 @@ class Config:
 
 print(dataconf.string(conf, Config))
 # Config(
-#   str_name='/users/root',
+#   str_name='/users/root/',
 #   dash_to_underscore=True,
 #   float_num=2.2,
+#   iso_datetime=datetime.datetime(2000, 1, 1, 20, 0),
+#   iso_duration=datetime.timedelta(days=123, seconds=14706),
+#   tuple_data=('a', datetime.timedelta(days=1)),
 #   list_data=['a', 'b'],
-#   nested=Nested(a='test'),
+#   nested=Nested(a='test', b=1),
 #   nested_list=[Nested(a='test1', b=2.5)],
-#   duration=relativedelta(seconds=+2), 
-#   union=1, 
-#   people=Person(name='Thailand'), 
+#   duration=relativedelta(seconds=+2),
+#   union=1,
+#   people=Person(name='Thailand'),
 #   zone=Zone(area_code=42),
-#   default='hello', 
+#   default='hello',
 #   default_factory={}
 # )
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ dash-to-underscore = true
 float_num = 2.2
 iso_datetime = "2000-01-01T20:00:00"
 iso_duration = "P123DT4H5M6S"
+variable_length_tuple_data = [
+    1
+    2
+    3
+]
 tuple_data = [
     a
     P1D
@@ -93,6 +98,7 @@ class Config:
     float_num: float
     iso_datetime: datetime
     iso_duration: timedelta
+    variable_length_tuple_data: Tuple[int, ...]
     tuple_data: Tuple[Text, timedelta]
     list_data: List[Text]
     nested: Nested
@@ -111,6 +117,7 @@ print(dataconf.string(conf, Config))
 #   float_num=2.2,
 #   iso_datetime=datetime.datetime(2000, 1, 1, 20, 0),
 #   iso_duration=datetime.timedelta(days=123, seconds=14706),
+#   variable_length_tuple_data=(1,2,3),
 #   tuple_data=('a', datetime.timedelta(days=1)),
 #   list_data=['a', 'b'],
 #   nested=Nested(a='test', b=1),

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -125,25 +125,25 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
         return None
 
     if origin is tuple:
-        if value is not None:
-            if len(args) < 1:
-                raise MissingTypeException(
-                    "expected tuple with type information: Tuple[?]"
-                )
-            has_ellipsis = args[-1] == Ellipsis
-            if has_ellipsis and len(args) != 2:
-                raise MissingTypeException(
-                    "expected one type since ellipsis is used: Tuple[?, ...]"
-                )
-            _args = args if not has_ellipsis else [args[0]] * len(value)
-            if len(value) > 0 and len(value) != len(_args):
-                raise MalformedConfigException(
-                    "number of provided values does not match expected number of values for tuple."
-                )
-            return tuple(
-                __parse(v, arg, f"{path}[]", strict, ignore_unexpected)
-                for v, arg in zip(value, _args)
+        if value is None:
+            return None
+
+        if len(args) < 1:
+            raise MissingTypeException("expected tuple with type information: Tuple[?]")
+        has_ellipsis = args[-1] == Ellipsis
+        if has_ellipsis and len(args) != 2:
+            raise MissingTypeException(
+                "expected one type since ellipsis is used: Tuple[?, ...]"
             )
+        _args = args if not has_ellipsis else [args[0]] * len(value)
+        if len(value) > 0 and len(value) != len(_args):
+            raise MalformedConfigException(
+                "number of provided values does not match expected number of values for tuple."
+            )
+        return tuple(
+            __parse(v, arg, f"{path}[]", strict, ignore_unexpected)
+            for v, arg in zip(value, _args)
+        )
 
     if origin is dict:
         if len(args) != 2:

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -8,8 +8,6 @@ from enum import Enum
 from enum import IntEnum
 from inspect import isclass
 from pathlib import Path
-from itertools import chain
-from itertools import repeat
 
 from typing import Any, Literal
 from typing import Dict
@@ -137,11 +135,7 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
                 raise MissingTypeException(
                     "expected one type since ellipsis is used: Tuple[?, ...]"
                 )
-            _args = (
-                args
-                if not has_ellipsis
-                else list(chain([args[0]], repeat(args[0], len(value) - 1)))
-            )
+            _args = args if not has_ellipsis else [args[0]] * len(value)
             if len(value) > 0 and len(value) != len(_args):
                 raise MalformedConfigException(
                     "number of provided values does not match expected number of values for tuple."

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -124,6 +124,17 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
             ]
         return None
 
+    if origin is tuple:
+        if value is not None:
+            if len(value) != len(args):
+                raise MalformedConfigException(
+                    "number of provided values does not match expected number of values for tuple."
+                )
+            return tuple(
+                __parse(v, arg, f"{path}[]", strict, ignore_unexpected)
+                for v, arg in zip(value, args)
+            )
+
     if origin is dict:
         if len(args) != 2:
             raise MissingTypeException(

--- a/dataconf/utils.py
+++ b/dataconf/utils.py
@@ -113,23 +113,27 @@ def __parse(value: any, clazz: Type, path: str, strict: bool, ignore_unexpected:
     args = get_args(clazz)
 
     if origin is list:
+        if value is None:
+            raise MalformedConfigException(f"expected list at {path} but received None")
+
         if len(args) != 1:
             raise MissingTypeException("expected list with type information: List[?]")
 
-        if value is not None:
-            parse_candidate = args[0]
-            return [
-                __parse(v, parse_candidate, f"{path}[]", strict, ignore_unexpected)
-                for v in value
-            ]
-        return None
+        parse_candidate = args[0]
+        return [
+            __parse(v, parse_candidate, f"{path}[]", strict, ignore_unexpected)
+            for v in value
+        ]
 
     if origin is tuple:
         if value is None:
-            return None
+            raise MalformedConfigException(
+                f"expected tuple at {path} but received None"
+            )
 
         if len(args) < 1:
             raise MissingTypeException("expected tuple with type information: Tuple[?]")
+
         has_ellipsis = args[-1] == Ellipsis
         if has_ellipsis and len(args) != 2:
             raise MissingTypeException(

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import os
-from typing import Text
+from typing import Text, Tuple
+from datetime import timedelta
 import urllib
 
 from dataconf import multi
@@ -12,10 +13,11 @@ class TestMulti:
         @dataclass
         class A:
             a: Text
+            b: Tuple[Text, timedelta]
 
-        expected = A(a="test")
-        assert multi.string("a = test").on(A) == expected
-        assert multi.dict({"a": "test"}).on(A) == expected
+        expected = A(a="test", b=("P1D", timedelta(days=1)))
+        assert multi.string("a = test\nb = [P1D\nP1D]").on(A) == expected
+        assert multi.dict({"a": "test", "b": ("P1D", "P1D")}).on(A) == expected
 
     def test_chain(self) -> None:
         @dataclass

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -14,10 +14,13 @@ class TestMulti:
         class A:
             a: Text
             b: Tuple[Text, timedelta]
+            c: Tuple[int, ...]
 
-        expected = A(a="test", b=("P1D", timedelta(days=1)))
-        assert multi.string("a = test\nb = [P1D\nP1D]").on(A) == expected
-        assert multi.dict({"a": "test", "b": ("P1D", "P1D")}).on(A) == expected
+        expected = A(a="test", b=("P1D", timedelta(days=1)), c=(1,))
+        assert multi.string("a = test\nb = [P1D\nP1D]\nc = [1]").on(A) == expected
+        assert (
+            multi.dict({"a": "test", "b": ("P1D", "P1D"), "c": (1,)}).on(A) == expected
+        )
 
     def test_chain(self) -> None:
         @dataclass

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -12,6 +12,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Text
+from typing import Tuple
 from typing import Union
 
 import dataconf
@@ -110,6 +111,19 @@ class TestParser:
         ]
         """
         assert loads(conf, A) == A(a=["test"])
+
+    def test_tuple(self) -> None:
+        @dataclass
+        class A:
+            a: Tuple[str, timedelta]
+
+        conf = """
+        a = [
+            test,
+            P1D
+        ]
+        """
+        assert loads(conf, A) == A(a=("test", timedelta(days=1)))
 
     def test_boolean(self) -> None:
         @dataclass

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -103,27 +103,29 @@ class TestParser:
     def test_list(self) -> None:
         @dataclass
         class A:
-            a: List[Text]
+            b: List[Text]
 
         conf = """
-        a = [
+        b = [
             test
         ]
         """
-        assert loads(conf, A) == A(a=["test"])
+        assert loads(conf, A) == A(b=["test"])
+        assert loads("b = null", A) == A(b=None)
 
     def test_tuple(self) -> None:
         @dataclass
         class A:
-            a: Tuple[str, timedelta]
+            b: Tuple[str, timedelta]
 
         conf = """
-        a = [
+        b = [
             test,
             P1D
         ]
         """
-        assert loads(conf, A) == A(a=("test", timedelta(days=1)))
+        assert loads(conf, A) == A(b=("test", timedelta(days=1)))
+        assert loads("b = null", A) == A(b=None)
 
     def test_boolean(self) -> None:
         @dataclass
@@ -446,6 +448,9 @@ class TestParser:
 
         with pytest.raises(MissingTypeException):
             loads("", List)
+
+        with pytest.raises(MissingTypeException):
+            loads("", Tuple)
 
     def test_missing_field(self) -> None:
         @dataclass

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -111,7 +111,9 @@ class TestParser:
         ]
         """
         assert loads(conf, A) == A(b=["test"])
-        assert loads("b = null", A) == A(b=None)
+
+        with pytest.raises(MalformedConfigException):
+            loads("b = null", A)
 
     def test_tuple(self) -> None:
         @dataclass
@@ -125,7 +127,8 @@ class TestParser:
         ]
         """
         assert loads(conf, A) == A(b=("test", timedelta(days=1)))
-        assert loads("b = null", A) == A(b=None)
+        with pytest.raises(MalformedConfigException):
+            loads("b = null", A)
 
     def test_boolean(self) -> None:
         @dataclass

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -382,6 +382,39 @@ class TestParser:
         conf = ""
         assert loads(conf, A) == A(b=[])
 
+    def test_empty_tuple(self) -> None:
+        @dataclass
+        class A:
+            b: Tuple[str, ...] = field(default_factory=tuple)
+
+        conf = ""
+        assert loads(conf, A) == A(b=())
+
+    def test_fixed_length_tuple(self) -> None:
+        @dataclass
+        class A:
+            b: Tuple[int, str, timedelta]
+
+        conf = """
+        {
+            "b": [1, "2", "P1D"]
+        }
+        """
+        assert loads(conf, A) == A(b=(1, "2", timedelta(days=1)))
+
+    def test_fixed_length_mismatch(self) -> None:
+        @dataclass
+        class A:
+            b: Tuple[int, str, timedelta]
+
+        conf = """
+        {
+            "b": [1, "2"]
+        }
+        """
+        with pytest.raises(MalformedConfigException):
+            loads(conf, A)
+
     def test_json(self) -> None:
         @dataclass
         class A:
@@ -694,6 +727,33 @@ class TestParser:
         }
         """
         assert loads(conf, Base).foo == [{"a": 1}, [2]]
+
+    def test_tuple_any(self) -> None:
+        @dataclass
+        class Base:
+            foo: Tuple[Any, ...]
+
+        conf = """
+        {
+            foo: [
+                1
+                "b"
+            ]
+        }
+        """
+        assert loads(conf, Base).foo == (1, "b")
+
+        conf = """
+        {
+            foo: [
+                {a: 1}
+                [
+                    2
+                ]
+            ]
+        }
+        """
+        assert loads(conf, Base).foo == ({"a": 1}, [2])
 
     def test_yaml(self) -> None:
         @dataclass


### PR DESCRIPTION
This is intended to address #147. This will provide a way to create hashable dataclasses even when they have a field that is needs to be an iterable.